### PR TITLE
第4章：意図を語るテスト

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -1,7 +1,7 @@
 # TODOリスト
 - [ ] $5 + 10 CHF = $10(レートが2:1の場合)
 - [x] $5 * 2 = $10
-- [ ] amount を private にする
+- [x] amount を private にする
 - [x] Dollar の副作用どうする？
 - [ ] Money の丸誤差どうする？
 - [x] equals()

--- a/app/money/src/Dollar.php
+++ b/app/money/src/Dollar.php
@@ -6,7 +6,7 @@ namespace Money;
 
 class Dollar
 {
-    public int $amount;
+    private int $amount;
 
     public function __construct(int $amount)
     {

--- a/app/money/tests/Unit/MoneyTest.php
+++ b/app/money/tests/Unit/MoneyTest.php
@@ -12,10 +12,8 @@ class MoneyTest extends TestCase
     public function testMultiplication()
     {
         $five = new Dollar(5);
-        $product = $five->times(2);
-        $this->assertSame(10, $product->amount);
-        $product = $five->times(3);
-        $this->assertSame(15, $product->amount);
+        $this->assertObjectEquals(new Dollar(10), $five->times(2));
+        $this->assertObjectEquals(new Dollar(15), $five->times(3));
     }
 
     public function testEquality()


### PR DESCRIPTION
第1部の多国通貨のうち、第4章：意図を語るテストの写経をした

# 思ったこと
* phpunitでequals使った等価性比較をしたいときは、assertEqualsじゃダメなんじゃよ〜〜〜[assertObjectEquals](https://phpunit.readthedocs.io/ja/latest/assertions.html#assertobjectequals)を使うんじゃ
    * まあ[2年前ぐらいにできた機能](https://github.com/sebastianbergmann/phpunit/commit/1dba8c3a4b2dd04a3ff1869f75daaeb6757a14ee#diff-a079fe74e8e4825c64b17bd9e814722ec52db2bd32d2f93e1ad36fdde9ba6250)なので、phpunit9.4以降でしか使えないのだけれども

# 困ったこと
* やっぱ他言語で写経しようとすると、知識いるでござるね・・・良い刺激にはなるんだが、やっぱ厳密な写経ではないな